### PR TITLE
Use https instead of http

### DIFF
--- a/fabric-compute-framework/pom.xml
+++ b/fabric-compute-framework/pom.xml
@@ -155,7 +155,7 @@
             </snapshots>
             <id>bintray-readytalk-maven</id>
             <name>bintray</name>
-            <url>http://dl.bintray.com/readytalk/maven</url>
+            <url>https://dl.bintray.com/readytalk/maven</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -165,7 +165,7 @@
             </snapshots>
             <id>bintray-readytalk-maven</id>
             <name>bintray-plugins</name>
-            <url>http://dl.bintray.com/readytalk/maven</url>
+            <url>https://dl.bintray.com/readytalk/maven</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Use https in repository url in order to prevent MITM attacks